### PR TITLE
Export `asString` directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,12 @@
 "use strict";
-exports.ISO8601_FORMAT = "yyyy-MM-dd hh:mm:ss.SSS";
-exports.ISO8601_WITH_TZ_OFFSET_FORMAT = "yyyy-MM-ddThh:mm:ssO";
-exports.DATETIME_FORMAT = "dd MM yyyy hh:mm:ss.SSS";
-exports.ABSOLUTETIME_FORMAT = "hh:mm:ss.SSS";
+
+module.exports = asString
+asString.asString = asString
+
+asString.ISO8601_FORMAT = "yyyy-MM-dd hh:mm:ss.SSS";
+asString.ISO8601_WITH_TZ_OFFSET_FORMAT = "yyyy-MM-ddThh:mm:ssO";
+asString.DATETIME_FORMAT = "dd MM yyyy hh:mm:ss.SSS";
+asString.ABSOLUTETIME_FORMAT = "hh:mm:ss.SSS";
 
 function padWithZeros(vNumber, width) {
   var numAsString = vNumber + "";
@@ -35,7 +39,7 @@ function offset(date) {
   return date.getTimezoneOffset() < 0 ? "+"+h+m : "-"+h+m;
 }
 
-exports.asString = function(/*format,*/ date) {
+function asString(/*format,*/ date) {
   var format = exports.ISO8601_FORMAT;
   if (typeof(date) === "string") {
     format = arguments[0];


### PR DESCRIPTION
This will allow for

``` js
var format = require('data-format')

format('YY', new Date())
```

The `asString.asString = asString` line is for back compat with the current `var format = require('data-format').asString` api.
