### PR TITLE
Use code fences for syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,36 @@ date-format
 
 node.js formatting of Date objects as strings. Probably exactly the same as some other library out there.
 
-        npm install date-format
+```sh
+npm install date-format
+```
 
 usage
 =====
 
-        var format = require('date-format');
-        format.asString(new Date()); //defaults to ISO8601 format
-        format.asString('hh:mm:ss.SSS', new Date()); //just the time
+```js
+var format = require('date-format');
+format.asString(new Date()); //defaults to ISO8601 format
+format.asString('hh:mm:ss.SSS', new Date()); //just the time
+```
 
 or
 
-        var format = require('date-format');
-        format(new Date());
-        format('hh:mm:ss.SSS', new Date());
-
+```js
+var format = require('date-format');
+format(new Date());
+format('hh:mm:ss.SSS', new Date());
+```
 
 Format string can be anything, but the following letters will be replaced (and leading zeroes added if necessary):
-* dd - date.getDate()
-* MM - date.getMonth() + 1
-* yy - date.getFullYear().toString().substring(2, 4)
-* yyyy - date.getFullYear()
-* hh - date.getHours()
-* mm - date.getMinutes()
-* ss - date.getSeconds()
-* SSS - date.getMilliseconds()
+* dd - `date.getDate()`
+* MM - `date.getMonth() + 1`
+* yy - `date.getFullYear().toString().substring(2, 4)`
+* yyyy - `date.getFullYear()`
+* hh - `date.getHours()`
+* mm - `date.getMinutes()`
+* ss - `date.getSeconds()`
+* SSS - `date.getMilliseconds()`
 * O - timezone offset in +hm format
 
 That's it.


### PR DESCRIPTION
I changed the formatting of the README to to use ```js because github will syntax highlight that code as javascript.

I also wrapped the js expressions in the list in code ticks to make it more obvious that they are javascript expressions
