### PR TITLE
feature: use given date for missing parse values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,15 @@
-'use strict';
+"use strict";
 
 function padWithZeros(vNumber, width) {
-    var numAsString = vNumber.toString();
-    while (numAsString.length < width) {
-        numAsString = '0' + numAsString;
-    }
-    return numAsString;
+  var numAsString = vNumber.toString();
+  while (numAsString.length < width) {
+    numAsString = "0" + numAsString;
+  }
+  return numAsString;
 }
 
 function addZero(vNumber) {
-    return padWithZeros(vNumber, 2);
+  return padWithZeros(vNumber, 2);
 }
 
 /**
@@ -18,108 +18,164 @@ function addZero(vNumber) {
  * @private
  */
 function offset(timezoneOffset) {
-    var os = Math.abs(timezoneOffset);
-    var h = String(Math.floor(os / 60));
-    var m = String(os % 60);
-    if (h.length === 1) {
-        h = '0' + h;
-    }
-    if (m.length === 1) {
-        m = '0' + m;
-    }
-    return timezoneOffset < 0 ? '+' + h + m : '-' + h + m;
+  var os = Math.abs(timezoneOffset);
+  var h = String(Math.floor(os / 60));
+  var m = String(os % 60);
+  if (h.length === 1) {
+    h = "0" + h;
+  }
+  if (m.length === 1) {
+    m = "0" + m;
+  }
+  return timezoneOffset < 0 ? "+" + h + m : "-" + h + m;
 }
 
 function datePart(date, displayUTC, part) {
-  return displayUTC ? date['getUTC' + part]() : date['get' + part]();
+  return displayUTC ? date["getUTC" + part]() : date["get" + part]();
 }
 
 function asString(format, date) {
-    if (typeof format !== 'string') {
-        date = format;
-        format = module.exports.ISO8601_FORMAT;
-    }
-    if (!date) {
-        date =  module.exports.now();
-    }
+  if (typeof format !== "string") {
+    date = format;
+    format = module.exports.ISO8601_FORMAT;
+  }
+  if (!date) {
+    date = module.exports.now();
+  }
 
-    var displayUTC = format.indexOf('O') > -1;
+  var displayUTC = format.indexOf("O") > -1;
 
-    var vDay = addZero(datePart(date, displayUTC, 'Date'));
-    var vMonth = addZero(datePart(date, displayUTC, 'Month') + 1);
-    var vYearLong = addZero(datePart(date, displayUTC, 'FullYear'));
-    var vYearShort = addZero(vYearLong.substring(2, 4));
-    var vYear = (format.indexOf('yyyy') > -1 ? vYearLong : vYearShort);
-    var vHour = addZero(datePart(date, displayUTC, 'Hours'));
-    var vMinute = addZero(datePart(date, displayUTC, 'Minutes'));
-    var vSecond = addZero(datePart(date, displayUTC, 'Seconds'));
-    var vMillisecond = padWithZeros(datePart(date, displayUTC, 'Milliseconds'), 3);
-    var vTimeZone = offset(date.getTimezoneOffset());
-    var formatted = format
-        .replace(/dd/g, vDay)
-        .replace(/MM/g, vMonth)
-        .replace(/y{1,4}/g, vYear)
-        .replace(/hh/g, vHour)
-        .replace(/mm/g, vMinute)
-        .replace(/ss/g, vSecond)
-        .replace(/SSS/g, vMillisecond)
-        .replace(/O/g, vTimeZone);
-    return formatted;
+  var vDay = addZero(datePart(date, displayUTC, "Date"));
+  var vMonth = addZero(datePart(date, displayUTC, "Month") + 1);
+  var vYearLong = addZero(datePart(date, displayUTC, "FullYear"));
+  var vYearShort = addZero(vYearLong.substring(2, 4));
+  var vYear = format.indexOf("yyyy") > -1 ? vYearLong : vYearShort;
+  var vHour = addZero(datePart(date, displayUTC, "Hours"));
+  var vMinute = addZero(datePart(date, displayUTC, "Minutes"));
+  var vSecond = addZero(datePart(date, displayUTC, "Seconds"));
+  var vMillisecond = padWithZeros(
+    datePart(date, displayUTC, "Milliseconds"),
+    3
+  );
+  var vTimeZone = offset(date.getTimezoneOffset());
+  var formatted = format
+    .replace(/dd/g, vDay)
+    .replace(/MM/g, vMonth)
+    .replace(/y{1,4}/g, vYear)
+    .replace(/hh/g, vHour)
+    .replace(/mm/g, vMinute)
+    .replace(/ss/g, vSecond)
+    .replace(/SSS/g, vMillisecond)
+    .replace(/O/g, vTimeZone);
+  return formatted;
 }
 
-function extractDateParts(pattern, str) {
+function extractDateParts(pattern, str, missingValuesDate) {
   var matchers = [
-    { pattern: /y{1,4}/, regexp: "\\d{1,4}", fn: function(date, value) { date.setFullYear(value); } },
-    { pattern: /MM/, regexp: "\\d{1,2}", fn: function(date, value) { date.setMonth(value -1); } },
-    { pattern: /dd/, regexp: "\\d{1,2}", fn: function(date, value) { date.setDate(value); } },
-    { pattern: /hh/, regexp: "\\d{1,2}", fn: function(date, value) { date.setHours(value); } },
-    { pattern: /mm/, regexp: "\\d\\d", fn: function(date, value) { date.setMinutes(value); } },
-    { pattern: /ss/, regexp: "\\d\\d", fn: function(date, value) { date.setSeconds(value); } },
-    { pattern: /SSS/, regexp: "\\d\\d\\d", fn: function(date, value) { date.setMilliseconds(value); } },
-    { pattern: /O/, regexp: "[+-]\\d{3,4}|Z", fn: function(date, value) {
-      if (value === 'Z') {
-        value = 0;
+    {
+      pattern: /y{1,4}/,
+      regexp: "\\d{1,4}",
+      fn: function(date, value) {
+        date.setFullYear(value);
       }
-      var offset = Math.abs(value);
-      var minutes = (offset % 100) + (Math.floor(offset / 100) * 60);
-      date.setMinutes(date.getMinutes() + (value > 0 ? minutes : -minutes));
-    } }
+    },
+    {
+      pattern: /MM/,
+      regexp: "\\d{1,2}",
+      fn: function(date, value) {
+        date.setMonth(value - 1);
+      }
+    },
+    {
+      pattern: /dd/,
+      regexp: "\\d{1,2}",
+      fn: function(date, value) {
+        date.setDate(value);
+      }
+    },
+    {
+      pattern: /hh/,
+      regexp: "\\d{1,2}",
+      fn: function(date, value) {
+        date.setHours(value);
+      }
+    },
+    {
+      pattern: /mm/,
+      regexp: "\\d\\d",
+      fn: function(date, value) {
+        date.setMinutes(value);
+      }
+    },
+    {
+      pattern: /ss/,
+      regexp: "\\d\\d",
+      fn: function(date, value) {
+        date.setSeconds(value);
+      }
+    },
+    {
+      pattern: /SSS/,
+      regexp: "\\d\\d\\d",
+      fn: function(date, value) {
+        date.setMilliseconds(value);
+      }
+    },
+    {
+      pattern: /O/,
+      regexp: "[+-]\\d{3,4}|Z",
+      fn: function(date, value) {
+        if (value === "Z") {
+          value = 0;
+        }
+        var offset = Math.abs(value);
+        var minutes = (offset % 100) + Math.floor(offset / 100) * 60;
+        date.setMinutes(date.getMinutes() + (value > 0 ? minutes : -minutes));
+      }
+    }
   ];
 
-  var parsedPattern = matchers.reduce(function(p, m) {
-    if (m.pattern.test(p.regexp)) {
-      m.index = p.regexp.match(m.pattern).index;
-      p.regexp = p.regexp.replace(m.pattern, "(" + m.regexp + ")");
-    } else {
-      m.index = -1;
-    }
-    return p;
-  }, { regexp: pattern, index: [] });
+  var parsedPattern = matchers.reduce(
+    function(p, m) {
+      if (m.pattern.test(p.regexp)) {
+        m.index = p.regexp.match(m.pattern).index;
+        p.regexp = p.regexp.replace(m.pattern, "(" + m.regexp + ")");
+      } else {
+        m.index = -1;
+      }
+      return p;
+    },
+    { regexp: pattern, index: [] }
+  );
 
   var dateFns = matchers.filter(function(m) {
     return m.index > -1;
   });
-  dateFns.sort(function(a, b) { return a.index - b.index; });
+  dateFns.sort(function(a, b) {
+    return a.index - b.index;
+  });
 
   var matcher = new RegExp(parsedPattern.regexp);
   var matches = matcher.exec(str);
   if (matches) {
-    var date = module.exports.now();
+    var date = missingValuesDate || module.exports.now();
     dateFns.forEach(function(f, i) {
-      f.fn(date, matches[i+1]);
+      f.fn(date, matches[i + 1]);
     });
     return date;
   }
 
-  throw new Error('String \'' + str + '\' could not be parsed as \'' + pattern + '\'');
+  throw new Error(
+    "String '" + str + "' could not be parsed as '" + pattern + "'"
+  );
 }
 
-function parse(pattern, str) {
+function parse(pattern, str, missingValuesDate) {
   if (!pattern) {
-    throw new Error('pattern must be supplied');
+    throw new Error("pattern must be supplied");
   }
 
-  return extractDateParts(pattern, str);
+  return extractDateParts(pattern, str, missingValuesDate);
 }
 
 /**
@@ -133,7 +189,7 @@ module.exports = asString;
 module.exports.asString = asString;
 module.exports.parse = parse;
 module.exports.now = now;
-module.exports.ISO8601_FORMAT = 'yyyy-MM-ddThh:mm:ss.SSS';
-module.exports.ISO8601_WITH_TZ_OFFSET_FORMAT = 'yyyy-MM-ddThh:mm:ss.SSSO';
-module.exports.DATETIME_FORMAT = 'dd MM yyyy hh:mm:ss.SSS';
-module.exports.ABSOLUTETIME_FORMAT = 'hh:mm:ss.SSS';
+module.exports.ISO8601_FORMAT = "yyyy-MM-ddThh:mm:ss.SSS";
+module.exports.ISO8601_WITH_TZ_OFFSET_FORMAT = "yyyy-MM-ddThh:mm:ss.SSSO";
+module.exports.DATETIME_FORMAT = "dd MM yyyy hh:mm:ss.SSS";
+module.exports.ABSOLUTETIME_FORMAT = "hh:mm:ss.SSS";

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -1,31 +1,37 @@
-'use strict';
+"use strict";
 
-require('should');
-var dateFormat = require('../lib');
+require("should");
+var dateFormat = require("../lib");
 
-describe('dateFormat.parse', function() {
-  it('should require a pattern', function() {
-    (function() { dateFormat.parse() }).should.throw(/pattern must be supplied/);
-    (function() { dateFormat.parse(null) }).should.throw(/pattern must be supplied/);
-    (function() { dateFormat.parse('') }).should.throw(/pattern must be supplied/);
+describe("dateFormat.parse", function() {
+  it("should require a pattern", function() {
+    (function() {
+      dateFormat.parse();
+    }.should.throw(/pattern must be supplied/));
+    (function() {
+      dateFormat.parse(null);
+    }.should.throw(/pattern must be supplied/));
+    (function() {
+      dateFormat.parse("");
+    }.should.throw(/pattern must be supplied/));
   });
 
-  describe('with a pattern that has no replacements', function() {
-    it('should return a new date when the string matches', function() {
-      dateFormat.parse('cheese', 'cheese').should.be.a.Date()
+  describe("with a pattern that has no replacements", function() {
+    it("should return a new date when the string matches", function() {
+      dateFormat.parse("cheese", "cheese").should.be.a.Date();
     });
 
-    it('should throw if the string does not match', function() {
+    it("should throw if the string does not match", function() {
       (function() {
-        dateFormat.parse('cheese', 'biscuits');
-      }).should.throw(/String 'biscuits' could not be parsed as 'cheese'/);
+        dateFormat.parse("cheese", "biscuits");
+      }.should.throw(/String 'biscuits' could not be parsed as 'cheese'/));
     });
   });
 
-  describe('with a full pattern', function() {
-    var pattern = 'yyyy-MM-dd hh:mm:ss.SSSO';
+  describe("with a full pattern", function() {
+    var pattern = "yyyy-MM-dd hh:mm:ss.SSSO";
 
-    it('should return the correct date if the string matches', function() {
+    it("should return the correct date if the string matches", function() {
       var testDate = new Date();
       testDate.setFullYear(2018);
       testDate.setMonth(8);
@@ -34,21 +40,30 @@ describe('dateFormat.parse', function() {
       testDate.setMinutes(10);
       testDate.setSeconds(12);
       testDate.setMilliseconds(392);
-      testDate.getTimezoneOffset = function() { return 600; };
+      testDate.getTimezoneOffset = function() {
+        return 600;
+      };
 
-      dateFormat.parse(pattern, '2018-09-13 08:10:12.392+1000').getTime().should.eql(testDate.getTime());
+      dateFormat
+        .parse(pattern, "2018-09-13 08:10:12.392+1000")
+        .getTime()
+        .should.eql(testDate.getTime());
     });
 
-    it('should throw if the string does not match', function() {
+    it("should throw if the string does not match", function() {
       (function() {
-        dateFormat.parse(pattern, 'biscuits')
-      }).should.throw(/String 'biscuits' could not be parsed as 'yyyy-MM-dd hh:mm:ss.SSSO'/);
+        dateFormat.parse(pattern, "biscuits");
+      }.should.throw(
+        /String 'biscuits' could not be parsed as 'yyyy-MM-dd hh:mm:ss.SSSO'/
+      ));
     });
   });
 
-  describe('with a partial pattern', function() {
+  describe("with a partial pattern", function() {
     var testDate = new Date();
-    dateFormat.now = function() { return testDate; };
+    dateFormat.now = function() {
+      return testDate;
+    };
 
     function verifyDate(actual, expected) {
       actual.getFullYear().should.eql(expected.year || testDate.getFullYear());
@@ -57,53 +72,69 @@ describe('dateFormat.parse', function() {
       actual.getHours().should.eql(expected.hours || testDate.getHours());
       actual.getMinutes().should.eql(expected.minutes || testDate.getMinutes());
       actual.getSeconds().should.eql(expected.seconds || testDate.getSeconds());
-      actual.getMilliseconds().should.eql(expected.milliseconds || testDate.getMilliseconds());
+      actual
+        .getMilliseconds()
+        .should.eql(expected.milliseconds || testDate.getMilliseconds());
     }
 
-    it('should return a date with missing values defaulting to current time', function() {
-      var date = dateFormat.parse('yyyy-MM', '2015-09');
+    it("should return a date with missing values defaulting to current time", function() {
+      var date = dateFormat.parse("yyyy-MM", "2015-09");
       verifyDate(date, { year: 2015, month: 8 });
     });
 
-    it('should handle variations on the same pattern', function() {
-      var date = dateFormat.parse('MM-yyyy', '09-2015');
+    it("should use a passed in date for missing values", function() {
+      var missingValueDate = new Date(2010, 1, 11, 10, 30, 12, 100);
+      var date = dateFormat.parse("yyyy-MM", "2015-09", missingValueDate);
+      verifyDate(date, {
+        year: 2015,
+        month: 8,
+        day: 11,
+        hours: 10,
+        minutes: 30,
+        seconds: 12,
+        milliseconds: 100
+      });
+    });
+
+    it("should handle variations on the same pattern", function() {
+      var date = dateFormat.parse("MM-yyyy", "09-2015");
       verifyDate(date, { year: 2015, month: 8 });
 
-      date = dateFormat.parse('yyyy MM', '2015 09');
+      date = dateFormat.parse("yyyy MM", "2015 09");
       verifyDate(date, { year: 2015, month: 8 });
 
-      date = dateFormat.parse('MM, yyyy.', '09, 2015.');
+      date = dateFormat.parse("MM, yyyy.", "09, 2015.");
       verifyDate(date, { year: 2015, month: 8 });
     });
 
-    it('should match all the date parts', function() {
-      var date = dateFormat.parse('dd', '21');
+    it("should match all the date parts", function() {
+      var date = dateFormat.parse("dd", "21");
       verifyDate(date, { day: 21 });
 
-      date = dateFormat.parse('hh', '12');
+      date = dateFormat.parse("hh", "12");
       verifyDate(date, { hours: 12 });
 
-      date = dateFormat.parse('mm', '34');
-      verifyDate(date,  { minutes: 34 });
+      date = dateFormat.parse("mm", "34");
+      verifyDate(date, { minutes: 34 });
 
-      date = dateFormat.parse('ss', '59');
+      date = dateFormat.parse("ss", "59");
       verifyDate(date, { seconds: 59 });
 
-      date = dateFormat.parse('ss.SSS', '23.452');
+      date = dateFormat.parse("ss.SSS", "23.452");
       verifyDate(date, { seconds: 23, milliseconds: 452 });
 
-      date = dateFormat.parse('hh:mm O', '05:23 +1000');
+      date = dateFormat.parse("hh:mm O", "05:23 +1000");
       verifyDate(date, { hours: 15, minutes: 23 });
 
-      date = dateFormat.parse('hh:mm O', '05:23 -200');
+      date = dateFormat.parse("hh:mm O", "05:23 -200");
       verifyDate(date, { hours: 3, minutes: 23 });
 
-      date = dateFormat.parse('hh:mm O', '05:23 +0930');
+      date = dateFormat.parse("hh:mm O", "05:23 +0930");
       verifyDate(date, { hours: 14, minutes: 53 });
     });
   });
 
-  describe('with a date formatted by this library', function() {
+  describe("with a date formatted by this library", function() {
     var testDate = new Date();
     testDate.setUTCFullYear(2018);
     testDate.setUTCMonth(8);
@@ -113,27 +144,34 @@ describe('dateFormat.parse', function() {
     testDate.setUTCSeconds(12);
     testDate.setUTCMilliseconds(392);
 
-    it('should format and then parse back to the same date', function() {
-      dateFormat.parse(
-        dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT,
-        dateFormat(dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT, testDate)
-      ).should.eql(testDate);
+    it("should format and then parse back to the same date", function() {
+      dateFormat
+        .parse(
+          dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT,
+          dateFormat(dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT, testDate)
+        )
+        .should.eql(testDate);
 
-      dateFormat.parse(
-        dateFormat.ISO8601_FORMAT,
-        dateFormat(dateFormat.ISO8601_FORMAT, testDate)
-      ).should.eql(testDate);
+      dateFormat
+        .parse(
+          dateFormat.ISO8601_FORMAT,
+          dateFormat(dateFormat.ISO8601_FORMAT, testDate)
+        )
+        .should.eql(testDate);
 
-      dateFormat.parse(
-        dateFormat.DATETIME_FORMAT,
-        dateFormat(dateFormat.DATETIME_FORMAT, testDate)
-      ).should.eql(testDate);
+      dateFormat
+        .parse(
+          dateFormat.DATETIME_FORMAT,
+          dateFormat(dateFormat.DATETIME_FORMAT, testDate)
+        )
+        .should.eql(testDate);
 
-      dateFormat.parse(
-        dateFormat.ABSOLUTETIME_FORMAT,
-        dateFormat(dateFormat.ABSOLUTETIME_FORMAT, testDate)
-      ).should.eql(testDate);
+      dateFormat
+        .parse(
+          dateFormat.ABSOLUTETIME_FORMAT,
+          dateFormat(dateFormat.ABSOLUTETIME_FORMAT, testDate)
+        )
+        .should.eql(testDate);
     });
-
   });
 });


### PR DESCRIPTION
This adds an extra optional argument to `parse`, a Date object to use for the missing values of a partial pattern (instead of using `now`). This can be used to make the parsing a bit more deterministic - calling parse with the same pattern and Date object will always give the same result.