### PR TITLE
Reinstate skipped tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,10 +30,6 @@ function offset(timezoneOffset) {
   return timezoneOffset < 0 ? "+" + h + m : "-" + h + m;
 }
 
-function datePart(date, part) {
-  return date["get" + part]();
-}
-
 function asString(format, date) {
   if (typeof format !== "string") {
     date = format;
@@ -47,18 +43,15 @@ function asString(format, date) {
   // with timezone info.
   // See https://en.wikipedia.org/wiki/ISO_8601 section "Time offsets from UTC"
 
-  var vDay = addZero(datePart(date, "Date"));
-  var vMonth = addZero(datePart(date, "Month") + 1);
-  var vYearLong = addZero(datePart(date, "FullYear"));
+  var vDay = addZero(date.getDate());
+  var vMonth = addZero(date.getMonth() + 1);
+  var vYearLong = addZero(date.getFullYear());
   var vYearShort = addZero(vYearLong.substring(2, 4));
   var vYear = format.indexOf("yyyy") > -1 ? vYearLong : vYearShort;
-  var vHour = addZero(datePart(date, "Hours"));
-  var vMinute = addZero(datePart(date, "Minutes"));
-  var vSecond = addZero(datePart(date, "Seconds"));
-  var vMillisecond = padWithZeros(
-    datePart(date, "Milliseconds"),
-    3
-  );
+  var vHour = addZero(date.getHours());
+  var vMinute = addZero(date.getMinutes());
+  var vSecond = addZero(date.getSeconds());
+  var vMillisecond = padWithZeros(date.getMilliseconds(), 3);
   var vTimeZone = offset(date.getTimezoneOffset());
   var formatted = format
     .replace(/dd/g, vDay)

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,8 +30,8 @@ function offset(timezoneOffset) {
   return timezoneOffset < 0 ? "+" + h + m : "-" + h + m;
 }
 
-function datePart(date, displayUTC, part) {
-  return displayUTC ? date["getUTC" + part]() : date["get" + part]();
+function datePart(date, part) {
+  return date["get" + part]();
 }
 
 function asString(format, date) {
@@ -44,20 +44,19 @@ function asString(format, date) {
   }
 
   // Issue # 14 - Per ISO8601 standard, the time string should be local time
-  // with timezone info.  
+  // with timezone info.
   // See https://en.wikipedia.org/wiki/ISO_8601 section "Time offsets from UTC"
-  var displayUTC = false;
 
-  var vDay = addZero(datePart(date, displayUTC, "Date"));
-  var vMonth = addZero(datePart(date, displayUTC, "Month") + 1);
-  var vYearLong = addZero(datePart(date, displayUTC, "FullYear"));
+  var vDay = addZero(datePart(date, "Date"));
+  var vMonth = addZero(datePart(date, "Month") + 1);
+  var vYearLong = addZero(datePart(date, "FullYear"));
   var vYearShort = addZero(vYearLong.substring(2, 4));
   var vYear = format.indexOf("yyyy") > -1 ? vYearLong : vYearShort;
-  var vHour = addZero(datePart(date, displayUTC, "Hours"));
-  var vMinute = addZero(datePart(date, displayUTC, "Minutes"));
-  var vSecond = addZero(datePart(date, displayUTC, "Seconds"));
+  var vHour = addZero(datePart(date, "Hours"));
+  var vMinute = addZero(datePart(date, "Minutes"));
+  var vSecond = addZero(datePart(date, "Seconds"));
   var vMillisecond = padWithZeros(
-    datePart(date, displayUTC, "Milliseconds"),
+    datePart(date, "Milliseconds"),
     3
   );
   var vTimeZone = offset(date.getTimezoneOffset());
@@ -73,58 +72,63 @@ function asString(format, date) {
   return formatted;
 }
 
+function setDatePart(date, part, value, local) {
+  date['set' + (local ? '' : 'UTC') + part](value);
+}
+
 function extractDateParts(pattern, str, missingValuesDate) {
   // Javascript Date object doesn't support custom timezone.  Sets all felds as
   // GMT based to begin with.  If the timezone offset is provided, then adjust
   // it using provided timezone, otherwise, adjust it with the system timezone.
+  var local = pattern.indexOf('O') < 0;
   var matchers = [
     {
       pattern: /y{1,4}/,
       regexp: "\\d{1,4}",
       fn: function(date, value) {
-        date.setUTCFullYear(value);
+        setDatePart(date, 'FullYear', value, local);
       }
     },
     {
       pattern: /MM/,
       regexp: "\\d{1,2}",
       fn: function(date, value) {
-        date.setUTCMonth(value - 1);
+        setDatePart(date, 'Month', (value - 1), local);
       }
     },
     {
       pattern: /dd/,
       regexp: "\\d{1,2}",
       fn: function(date, value) {
-        date.setUTCDate(value);
+        setDatePart(date, 'Date', value, local);
       }
     },
     {
       pattern: /hh/,
       regexp: "\\d{1,2}",
       fn: function(date, value) {
-        date.setUTCHours(value);
+        setDatePart(date, 'Hours', value, local);
       }
     },
     {
       pattern: /mm/,
       regexp: "\\d\\d",
       fn: function(date, value) {
-        date.setUTCMinutes(value);
+        setDatePart(date, 'Minutes', value, local);
       }
     },
     {
       pattern: /ss/,
       regexp: "\\d\\d",
       fn: function(date, value) {
-        date.setUTCSeconds(value);
+        setDatePart(date, 'Seconds', value, local);
       }
     },
     {
       pattern: /SSS/,
       regexp: "\\d\\d\\d",
       fn: function(date, value) {
-        date.setMilliseconds(value);
+        setDatePart(date, 'Milliseconds', value, local);
       }
     },
     {
@@ -136,25 +140,25 @@ function extractDateParts(pattern, str, missingValuesDate) {
         }
         var offset = Math.abs(value);
         var timezoneOffset = (value > 0 ? -1 :  1 ) * ((offset % 100) + Math.floor(offset / 100) * 60);
-        // Per ISO8601 standard: UTC = local time - offset 
-        // 
+        // Per ISO8601 standard: UTC = local time - offset
+        //
         // For example, 2000-01-01T01:00:00-0700
         //   local time: 2000-01-01T01:00:00
         //   ==> UTC   : 2000-01-01T08:00:00 ( 01 - (-7) = 8 )
         //
-        // To make it even more confusing, the date.getTimezoneOffset() is 
+        // To make it even more confusing, the date.getTimezoneOffset() is
         // opposite sign of offset string in the ISO8601 standard.  So if offset
         // is '-0700' the getTimezoneOffset() would be (+)420. The line above
         // calculates timezoneOffset to matche Javascript's behavior.
         //
         // The date/time of the input is actually the local time, so the date
         // object that was constructed is actually local time even thought the
-        // UTC setters are used.  This means the date object's internal UTC 
-        // representation was wrong.  It needs to be fixed by substracting the 
+        // UTC setters are used.  This means the date object's internal UTC
+        // representation was wrong.  It needs to be fixed by substracting the
         // offset (or adding the offset minutes as they are opposite sign).
         //
         // Note: the time zone has to be processed after all other fileds are
-        // set.  The result would be incorrect if the offset was calculated 
+        // set.  The result would be incorrect if the offset was calculated
         // first then overriden by the other filed setters.
         date.setUTCMinutes(date.getUTCMinutes() + timezoneOffset);
       }
@@ -189,15 +193,6 @@ function extractDateParts(pattern, str, missingValuesDate) {
       f.fn(date, matches[i + 1]);
     });
 
-    // It first constructs the date object using the UTC setters.  If 
-    // missingValuesDate was given then it would be the local timezone.  Or if 
-    // the timezone was specified in the input, then the date object would have
-    // been adjusted accordingly by the /O/ pattern handler.  
-    // If the timezone was not specified with either mean, then it will adjust 
-    // the date result using the OS timezone.
-    if(!missingValuesDate && pattern.indexOf("O") < 0) {
-      date.setUTCMinutes(date.getUTCMinutes() + date.getTimezoneOffset());
-    }
     return date;
   }
 

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -124,10 +124,6 @@ describe("dateFormat.parse", function() {
     });
 
     describe("should match all the date parts", function() {
-      // Test cases without timezone are invalid as the result varies depends on
-      // OS timezone and the hour the test cases are executed.
-      // These use cases should not be supported in the first place.  Using
-      // them will ensure all your time filled with sadness.
       it("works with dd", function() {
         var date = dateFormat.parse("dd", "21");
         verifyLocalDate(date, { day: 21 });

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -63,9 +63,25 @@ describe("dateFormat.parse", function() {
       return testDate;
     };
 
+    /**
+     * If there's no timezone in the format, then we verify against the local date
+     */
+    function verifyLocalDate(actual, expected) {
+      actual.getFullYear().should.eql(expected.year || testDate.getFullYear());
+      actual.getMonth().should.eql(expected.month || testDate.getMonth());
+      actual.getDate().should.eql(expected.day || testDate.getDate());
+      actual.getHours().should.eql(expected.hours || testDate.getHours());
+      actual.getMinutes().should.eql(expected.minutes || testDate.getMinutes());
+      actual.getSeconds().should.eql(expected.seconds || testDate.getSeconds());
+      actual
+        .getMilliseconds()
+        .should.eql(expected.milliseconds || testDate.getMilliseconds());
+    }
+
+    /**
+     * If a timezone is specified, let's verify against the UTC time it is supposed to be
+     */
     function verifyDate(actual, expected) {
-      // To avoid OS timezone affecting the values, changing all comparisons to
-      // use UTC.
       actual.getUTCFullYear().should.eql(expected.year || testDate.getUTCFullYear());
       actual.getUTCMonth().should.eql(expected.month || testDate.getUTCMonth());
       actual.getUTCDate().should.eql(expected.day || testDate.getUTCDate());
@@ -79,30 +95,17 @@ describe("dateFormat.parse", function() {
 
     it("should return a date with missing values defaulting to current time", function() {
       var date = dateFormat.parse("yyyy-MM", "2015-09");
-      verifyDate(date, { year: 2015, month: 8 });
+      verifyLocalDate(date, { year: 2015, month: 8 });
     });
 
     it("should use a passed in date for missing values", function() {
-      var missingValueDate = new Date(Date.UTC(2010, 1, 8, 22, 30, 12, 100));
-      missingValueDate.setUTCMinutes(missingValueDate.getUTCMinutes() + missingValueDate.getTimezoneOffset());
+      var missingValueDate = new Date(2010, 1, 8, 22, 30, 12, 100);
       var date = dateFormat.parse("yyyy-MM", "2015-09", missingValueDate);
-      verifyDate(date, {
+      verifyLocalDate(date, {
         year: 2015,
         month: 8,
-        // The missing value date and the new date to be parsed might have 
-        // different DST in effect depending which timezone the operation system
-        // set to where this test case is run on.  We cannot hard code the 
-        // values for validation.  This is all caused by the Javascript Date 
-        // object doesn't support timezone.  The 'getTimezoneOffset()' method 
-        // can return different result running on different OS timezone and the
-        // date/time the date object was set to.
-        // As a matter of fact, the "missingValueDate" probably should not be 
-        // supported in the first place.  The proper solution is to have replace
-        // Javascript's Date with one that has timezone support.
-        // The result might be few hours off or plus / minus a day or two
-        // depending on the above mentioned reasons.
-        day: missingValueDate.getUTCDate(),
-        hours: missingValueDate.getUTCHours(),
+        day: 8,
+        hours: 22,
         minutes: 30,
         seconds: 12,
         milliseconds: 100
@@ -111,43 +114,43 @@ describe("dateFormat.parse", function() {
 
     it("should handle variations on the same pattern", function() {
       var date = dateFormat.parse("MM-yyyy", "09-2015");
-      verifyDate(date, { year: 2015, month: 8 });
+      verifyLocalDate(date, { year: 2015, month: 8 });
 
       date = dateFormat.parse("yyyy MM", "2015 09");
-      verifyDate(date, { year: 2015, month: 8 });
+      verifyLocalDate(date, { year: 2015, month: 8 });
 
       date = dateFormat.parse("MM, yyyy.", "09, 2015.");
-      verifyDate(date, { year: 2015, month: 8 });
+      verifyLocalDate(date, { year: 2015, month: 8 });
     });
 
     describe("should match all the date parts", function() {
       // Test cases without timezone are invalid as the result varies depends on
-      // OS timezone and the hour the test cases are executed.  
-      // These use cases should not be supported in the first place.  Using 
+      // OS timezone and the hour the test cases are executed.
+      // These use cases should not be supported in the first place.  Using
       // them will ensure all your time filled with sadness.
-      xit("works with dd", function() {
+      it("works with dd", function() {
         var date = dateFormat.parse("dd", "21");
-        verifyDate(date, { day: 21 });
+        verifyLocalDate(date, { day: 21 });
       });
 
-      xit("works with hh", function() {
+      it("works with hh", function() {
         var date = dateFormat.parse("hh", "12");
-        verifyDate(date, { hours: 12 });
+        verifyLocalDate(date, { hours: 12 });
       });
 
-      xit("works with mm", function() {
+      it("works with mm", function() {
         var date = dateFormat.parse("mm", "34");
-        verifyDate(date, { minutes: 34 });
+        verifyLocalDate(date, { minutes: 34 });
       });
 
       it("works with ss", function() {
         var date = dateFormat.parse("ss", "59");
-        verifyDate(date, { seconds: 59 });
+        verifyLocalDate(date, { seconds: 59 });
       });
 
       it("works with ss.SSS", function() {
         var date = dateFormat.parse("ss.SSS", "23.452");
-        verifyDate(date, { seconds: 23, milliseconds: 452 });
+        verifyLocalDate(date, { seconds: 23, milliseconds: 452 });
       });
 
       it("works with hh:mm O (+1000)", function() {
@@ -181,19 +184,7 @@ describe("dateFormat.parse", function() {
         return td;
       }
 
-      function testDateInitWithLocal() {
-        var td = new Date();
-        td.setFullYear(2018);
-        td.setMonth(8);
-        td.setDate(13);
-        td.setHours(18);
-        td.setMinutes(10);
-        td.setSeconds(12);
-        td.setMilliseconds(392);
-        return td;
-      }
-
-      xit("works with ISO8601_WITH_TZ_OFFSET_FORMAT", function() {
+      it("works with ISO8601_WITH_TZ_OFFSET_FORMAT", function() {
         // For this test case to work, the date object must be initialized with
         // UTC timezone
         var td = testDateInitWithUTC();
@@ -202,22 +193,15 @@ describe("dateFormat.parse", function() {
           .should.eql(td);
       });
 
-      // The followings test cases are invalid and would only work when running
-      // them with OS timezone set to UTC.  ISO8601 string is local time with 
-      // timezone info.  Essentially, when the ISO8601 string is converted to
-      // string without timezone, the timezone information is lost and not
-      // recoverable.
-      // These use cases will produce unpriditable results.  Use any of them if 
-      // you'd like to gamble or to make rest of your life miserable. 
-      xit("works with ISO8601_FORMAT", function() {
-        var td = testDateInitWithLocal();
+      it("works with ISO8601_FORMAT", function() {
+        var td = new Date();
         var d = dateFormat(dateFormat.ISO8601_FORMAT, td);
         var actual = dateFormat.parse(dateFormat.ISO8601_FORMAT, d);
         actual.should.eql(td);
       });
 
-      xit("works with DATETIME_FORMAT", function() {
-        var testDate = testDateInitWithLocal();
+      it("works with DATETIME_FORMAT", function() {
+        var testDate = new Date();
         dateFormat
         .parse(
           dateFormat.DATETIME_FORMAT,
@@ -226,8 +210,8 @@ describe("dateFormat.parse", function() {
         .should.eql(testDate);
       });
 
-      xit("works with ABSOLUTETIME_FORMAT", function() {
-        var testDate = testDateInitWithLocal();
+      it("works with ABSOLUTETIME_FORMAT", function() {
+        var testDate = new Date();
         dateFormat
         .parse(
           dateFormat.ABSOLUTETIME_FORMAT,


### PR DESCRIPTION
PR #16 fixed the incorrect format of the time + offset, but it also skipped a few tests which were no longer reliable. This PR tidies up some of the code, and puts the tests back - mainly by comparing against local dates, which should avoid any timezone or DST related errors.

Please take a look @danielwu68, see if I've done something stupid. 