### PR TITLE
Updating title of changelog to just be "Changelog", removing "log4js-node"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# log4js-node changelog
+# Changelog
 
 ## 4.0.1
 


### PR DESCRIPTION
Small item, but I noticed in your changelog that it says log4js-node. Is that a typo?