### PR TITLE
fix: date parsing errors #67

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,7 @@ function extractDateParts(pattern, str, missingValuesDate) {
   // GMT based to begin with.  If the timezone offset is provided, then adjust
   // it using provided timezone, otherwise, adjust it with the system timezone.
   var local = pattern.indexOf('O') < 0;
+  var monthOverflow = false;
   var matchers = [
     {
       pattern: /y{1,4}/,
@@ -83,12 +84,22 @@ function extractDateParts(pattern, str, missingValuesDate) {
       regexp: "\\d{1,2}",
       fn: function(date, value) {
         setDatePart(date, 'Month', (value - 1), local);
+        if (date.getMonth() !== (value - 1)) {
+          // in the event of 31 May --> 31 Feb --> 3 Mar
+          // this is correct behavior if no Date is involved
+          monthOverflow = true;
+        }
       }
     },
     {
       pattern: /dd/,
       regexp: "\\d{1,2}",
       fn: function(date, value) {
+        // in the event of 31 May --> 31 Feb --> 3 Mar
+        // reset Mar back to Feb, before setting the Date
+        if (monthOverflow) {
+          setDatePart(date, 'Month', (date.getMonth() - 1), local);
+        }
         setDatePart(date, 'Date', value, local);
       }
     },
@@ -149,7 +160,7 @@ function extractDateParts(pattern, str, missingValuesDate) {
         // representation was wrong.  It needs to be fixed by substracting the
         // offset (or adding the offset minutes as they are opposite sign).
         //
-        // Note: the time zone has to be processed after all other fileds are
+        // Note: the time zone has to be processed after all other fields are
         // set.  The result would be incorrect if the offset was calculated
         // first then overriden by the other filed setters.
         date.setUTCMinutes(date.getUTCMinutes() + timezoneOffset);

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -32,7 +32,7 @@ describe("dateFormat.parse", function() {
     var pattern = "yyyy-MM-dd hh:mm:ss.SSSO";
 
     it("should return the correct date if the string matches", function() {
-      var testDate = new Date();
+      var testDate = new Date("2018-09-14 04:10:12.392+1000");
       testDate.setUTCFullYear(2018);
       testDate.setUTCMonth(8);
       testDate.setUTCDate(13);
@@ -174,6 +174,43 @@ describe("dateFormat.parse", function() {
         var date = dateFormat.parse("hh:mm O", "05:23 Z");
         verifyDate(date, { hours: 5, minutes: 23 });
       });
+    });
+  });
+
+  describe("with a partial pattern and last day of month", function() {
+    var testDate = new Date("2022-05-31T00:00:00.000Z");
+
+    /**
+     * If there's no timezone in the format, then we verify against the local date
+     */
+    function verifyLocalDate(actual, expected) {
+      function hasValue(obj) {
+        return (obj !== null && obj !== undefined);
+      }
+      actual.getFullYear().should.eql(hasValue(expected.year) ? expected.year : testDate.getFullYear());
+      actual.getMonth().should.eql(hasValue(expected.month) ? expected.month : testDate.getMonth());
+      actual.getDate().should.eql(hasValue(expected.day) ? expected.day : testDate.getDate());
+      actual.getHours().should.eql(hasValue(expected.hours) ? expected.hours : testDate.getHours());
+      actual.getMinutes().should.eql(hasValue(expected.minutes) ? expected.minutes : testDate.getMinutes());
+      actual.getSeconds().should.eql(hasValue(expected.seconds) ? expected.seconds : testDate.getSeconds());
+      actual
+        .getMilliseconds()
+        .should.eql(hasValue(expected.milliseconds) ? expected.milliseconds : testDate.getMilliseconds());
+    }
+
+    it("should return a date with missing values defaulting to current time", function() {
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-01-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 0, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-02-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 1, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-03-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 2, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-04-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 3, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-05-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 4, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-06-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 5, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-07-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 6, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-08-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 7, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-09-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 8, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-10-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 9, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-11-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 10, day: 1});
+      verifyLocalDate(dateFormat.parse('yyyy-MM-dd', '2022-12-01', new Date("2022-05-31T00:00:00.000Z")), { year: 2022, month: 11, day: 1});
     });
   });
 

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -67,30 +67,36 @@ describe("dateFormat.parse", function() {
      * If there's no timezone in the format, then we verify against the local date
      */
     function verifyLocalDate(actual, expected) {
-      actual.getFullYear().should.eql(expected.year || testDate.getFullYear());
-      actual.getMonth().should.eql(expected.month || testDate.getMonth());
-      actual.getDate().should.eql(expected.day || testDate.getDate());
-      actual.getHours().should.eql(expected.hours || testDate.getHours());
-      actual.getMinutes().should.eql(expected.minutes || testDate.getMinutes());
-      actual.getSeconds().should.eql(expected.seconds || testDate.getSeconds());
+      function hasValue(obj) {
+        return (obj !== null && obj !== undefined);
+      }
+      actual.getFullYear().should.eql(hasValue(expected.year) ? expected.year : testDate.getFullYear());
+      actual.getMonth().should.eql(hasValue(expected.month) ? expected.month : testDate.getMonth());
+      actual.getDate().should.eql(hasValue(expected.day) ? expected.day : testDate.getDate());
+      actual.getHours().should.eql(hasValue(expected.hours) ? expected.hours : testDate.getHours());
+      actual.getMinutes().should.eql(hasValue(expected.minutes) ? expected.minutes : testDate.getMinutes());
+      actual.getSeconds().should.eql(hasValue(expected.seconds) ? expected.seconds : testDate.getSeconds());
       actual
         .getMilliseconds()
-        .should.eql(expected.milliseconds || testDate.getMilliseconds());
+        .should.eql(hasValue(expected.milliseconds) ? expected.milliseconds : testDate.getMilliseconds());
     }
 
     /**
      * If a timezone is specified, let's verify against the UTC time it is supposed to be
      */
     function verifyDate(actual, expected) {
-      actual.getUTCFullYear().should.eql(expected.year || testDate.getUTCFullYear());
-      actual.getUTCMonth().should.eql(expected.month || testDate.getUTCMonth());
-      actual.getUTCDate().should.eql(expected.day || testDate.getUTCDate());
-      actual.getUTCHours().should.eql(expected.hours || testDate.getUTCHours());
-      actual.getUTCMinutes().should.eql(expected.minutes || testDate.getUTCMinutes());
-      actual.getUTCSeconds().should.eql(expected.seconds || testDate.getUTCSeconds());
+      function hasValue(obj) {
+        return (obj !== null && obj !== undefined);
+      }
+      actual.getUTCFullYear().should.eql(hasValue(expected.year) ? expected.year : testDate.getUTCFullYear());
+      actual.getUTCMonth().should.eql(hasValue(expected.month) ? expected.month : testDate.getUTCMonth());
+      actual.getUTCDate().should.eql(hasValue(expected.day) ? expected.day : testDate.getUTCDate());
+      actual.getUTCHours().should.eql(hasValue(expected.hours) ? expected.hours : testDate.getUTCHours());
+      actual.getUTCMinutes().should.eql(hasValue(expected.minutes) ? expected.minutes : testDate.getUTCMinutes());
+      actual.getUTCSeconds().should.eql(hasValue(expected.seconds) ? expected.seconds : testDate.getUTCSeconds());
       actual
         .getMilliseconds()
-        .should.eql(expected.milliseconds || testDate.getMilliseconds());
+        .should.eql(hasValue(expected.milliseconds) ? expected.milliseconds : testDate.getMilliseconds());
     }
 
     it("should return a date with missing values defaulting to current time", function() {


### PR DESCRIPTION
before
---
```js
const format = require('date-format');
const endOfMonth = function() {
  return new Date("2022-05-31T00:00:00.000Z");
};
format.parse('yyyy-MM-dd', '2022-01-01', endOfMonth()); // 2022-01-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-02-01', endOfMonth()); // 2022-03-01T00:00:00.000Z  << wrong month
format.parse('yyyy-MM-dd', '2022-03-01', endOfMonth()); // 2022-03-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-04-01', endOfMonth()); // 2022-05-01T00:00:00.000Z  << wrong month
format.parse('yyyy-MM-dd', '2022-05-01', endOfMonth()); // 2022-05-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-06-01', endOfMonth()); // 2022-07-01T00:00:00.000Z  << wrong month
format.parse('yyyy-MM-dd', '2022-07-01', endOfMonth()); // 2022-07-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-08-01', endOfMonth()); // 2022-08-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-09-01', endOfMonth()); // 2022-10-01T10:02:37.851Z  << wrong month
format.parse('yyyy-MM-dd', '2022-10-01', endOfMonth()); // 2022-10-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-11-01', endOfMonth()); // 2022-12-01T00:00:00.000Z  << wrong month
format.parse('yyyy-MM-dd', '2022-12-01', endOfMonth()); // 2022-12-01T00:00:00.000Z
```

after
---
```js
const format = require('date-format');
const endOfMonth = function() {
  return new Date("2022-05-31T00:00:00.000Z");
};
format.parse('yyyy-MM-dd', '2022-01-01', endOfMonth()); // 2022-01-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-02-01', endOfMonth()); // 2022-02-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-03-01', endOfMonth()); // 2022-03-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-04-01', endOfMonth()); // 2022-04-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-05-01', endOfMonth()); // 2022-05-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-06-01', endOfMonth()); // 2022-06-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-07-01', endOfMonth()); // 2022-07-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-08-01', endOfMonth()); // 2022-08-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-09-01', endOfMonth()); // 2022-09-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-10-01', endOfMonth()); // 2022-10-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-11-01', endOfMonth()); // 2022-11-01T00:00:00.000Z
format.parse('yyyy-MM-dd', '2022-12-01', endOfMonth()); // 2022-12-01T00:00:00.000Z
```