### PR TITLE
test: use `new Date(0)` instead of `new Date()` before setting every field

### DIFF
--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -32,7 +32,7 @@ describe("dateFormat.parse", function() {
     var pattern = "yyyy-MM-dd hh:mm:ss.SSSO";
 
     it("should return the correct date if the string matches", function() {
-      var testDate = new Date("2018-09-14 04:10:12.392+1000");
+      var testDate = new Date(0);
       testDate.setUTCFullYear(2018);
       testDate.setUTCMonth(8);
       testDate.setUTCDate(13);
@@ -217,7 +217,7 @@ describe("dateFormat.parse", function() {
   describe("with a date formatted by this library", function() {
     describe("should format and then parse back to the same date", function() {
       function testDateInitWithUTC() {
-        var td = new Date();
+        var td = new Date(0);
         td.setUTCFullYear(2018);
         td.setUTCMonth(8);
         td.setUTCDate(13);


### PR DESCRIPTION
to avoid month overflow

running the tests on 31 May using `new Date()` to `setMonth(1)` (to Feb) will result in 3 March instead of Feb
`new Date(0)` will default the day to 1 (which will `setDate()` later anyway), to not have month overflow issues

before
---
```js
   var td = new Date("2022-05-31T00:00:00.000Z"); // simulate new Date() on 31 May
   // trying to set to 2018-02-13T18:10:12.392Z
   td.setUTCFullYear(2018);
   td.setUTCMonth(1);
   td.setUTCDate(13);
   td.setUTCHours(18);
   td.setUTCMinutes(10);
   td.setUTCSeconds(12);
   td.setUTCMilliseconds(392);

   console.log(td.toISOString()); 
  // expected 2018-02-13T18:10:12.392Z
  // actual   2018-03-13T18:10:12.392Z
  // wrong!
 ```

after
---
```js
   var td = new Date(0);
   // trying to set to 2018-02-13T18:10:12.392Z
   td.setUTCFullYear(2018);
   td.setUTCMonth(1);
   td.setUTCDate(13);
   td.setUTCHours(18);
   td.setUTCMinutes(10);
   td.setUTCSeconds(12);
   td.setUTCMilliseconds(392);

   console.log(td.toISOString()); 
  // expected 2018-02-13T18:10:12.392Z
  // actual   2018-02-13T18:10:12.392Z
  // correct!
 ```